### PR TITLE
Push rework - don't load entire file into memory

### DIFF
--- a/lib/usb-device.js
+++ b/lib/usb-device.js
@@ -255,7 +255,7 @@ class USBDevice {
                                           , localId
                                           , remoteId
                                           , sendBuffer);
-      if  (packet.data) {
+      if (packet.data) {
         console.log("packet data:", packet.data.toString());
       }
       sendBuffer = new Buffer("");

--- a/lib/usb-device.js
+++ b/lib/usb-device.js
@@ -211,104 +211,68 @@ class USBDevice {
     return fileData;
   }
 
-  // some fun stuff necessary to format buffers for pushing files
-  _constructFileBuffer (fileData, fileStats, devicePath) {
-    let currentPosition = 0; // current position in the file data buffer
-    let remaining = fileData.length;
-    let maxSize = 65536; // we can't send a DATA with more than 64k
-    let sendBuffer = new Buffer(`${devicePath},${fileStats.mode}`);
-    let sizeBuffer = new Buffer(4);
-    while (remaining > maxSize) {
-      sizeBuffer.writeUInt32LE(maxSize, 0);
-      let chunk = new Buffer(maxSize);
-      fileData.copy(chunk, 0, currentPosition, currentPosition + maxSize);
-      sendBuffer = Buffer.concat([sendBuffer, dataIndicator, sizeBuffer, chunk]);
-      remaining -= maxSize;
-      currentPosition += maxSize;
-    }
-    sizeBuffer.writeUInt32LE(remaining, 0);
-    let chunk = new Buffer(remaining);
-    fileData.copy(chunk, 0, currentPosition, currentPosition + remaining);
-    sendBuffer = Buffer.concat([sendBuffer, dataIndicator, sizeBuffer, chunk]);
-    let doneBuffer = new Buffer("DONE");
-    let mTimeBuffer = new Buffer(4);
-    mTimeBuffer.writeUInt32LE(fileStats.mtime.getTime() / 1000, 0);
-    sendBuffer = Buffer.concat([sendBuffer, doneBuffer, mTimeBuffer]);
-    return sendBuffer;
-  }
-
-  // loop through the dataBuffer, which consists of fileData and ADB related data
-  // necessary to push a file to the device
-  // async _fileLoop (dataBuffer, localId, remoteId) {
-  //   let remaining = dataBuffer.length;
-  //   let amountSent = 0;
-  //   let payloadBuffer = null;
-  //   while (remaining !== 0) {
-  //     if (remaining > maxRead) {
-  //       payloadBuffer = new Buffer(maxRead);
-  //       dataBuffer.copy(payloadBuffer, 0, amountSent, amountSent + maxRead);
-  //     } else {
-  //       payloadBuffer = new Buffer(remaining);
-  //       dataBuffer.copy(payloadBuffer, 0 , amountSent, dataBuffer.length);
-  //     }
-  //     let packet = await this._sendAndOkay(ADB_COMMANDS.CMD_WRTE
-  //                                         , localId
-  //                                         , remoteId
-  //                                         , payloadBuffer);
-  //     if (packet.data) {
-  //       console.log(packet.data.toString());
-  //     }
-  //     amountSent += payloadBuffer.length;
-  //     remaining -= payloadBuffer.length;
-  //   }
-  // }
+  // loops through a file and sends it to the device with all the required
+  // adb data and formatting in place, called by _sendFile
   async _fileLoop(filePath, fileStats, devicePath, localId, remoteId) {
-    let sendBuffer = new Buffer(`${devicePath},${fileStats.mode},`);
+    let sendBuffer = new Buffer(`${devicePath},${fileStats.mode}`);
     let fd = await openAsync(filePath, 'r');
     let remaining = fileStats.size;
     let currentPosition = 0;
+    let appendDataSize = true;
     // DATA<size> can only be 64k or less
     let dataAmount = remaining > MAX_SIZE ? MAX_SIZE : remaining;
     while (remaining > 0) {
-      if (dataAmount === (MAX_SIZE || remaining)) {
-        sendBuffer = Buffer.concat([sendBuffer, `DATA${dataAmount}`]);
+      if (appendDataSize) {
+        let sizeBuffer = new Buffer(4);
+        sizeBuffer.writeUInt32LE(dataAmount);
+        sendBuffer = Buffer.concat([sendBuffer, dataIndicator, sizeBuffer]);
+        appendDataSize = false;
       }
-      let amountToRead = remaining > MAX_READ ? MAX_READ : remaining;
+      let amountToRead = null;
+      if (sendBuffer.length === 0) {
+        amountToRead = dataAmount > MAX_READ ? MAX_READ : dataAmount;
+      } else {
+        amountToRead = MAX_READ - sendBuffer.length;
+      }
       let readBuffer = new Buffer(amountToRead);
       await readAsync(fd, readBuffer, 0, amountToRead, currentPosition);
       sendBuffer = Buffer.concat([sendBuffer, readBuffer]);
-      let packet = await this._sendAndOkay(ADB_COMMANDS.CMD_WRTE
-                                          , localId
-                                          , remoteId
-                                          , sendBuffer);
-      console.log("packet: ", packet);
       remaining -= amountToRead;
       dataAmount -= amountToRead;
       currentPosition += amountToRead;
       if (dataAmount === 0 && remaining !== 0) {
+        appendDataSize = true;
         dataAmount = remaining > MAX_SIZE ? MAX_SIZE : remaining;
+        continue;
       }
+      if (remaining === 0) {
+        let doneBuffer = new Buffer("DONE");
+        let mTimeBuffer = new Buffer(4);
+        mTimeBuffer.writeUInt32LE(fileStats.mtime.getTime() / 1000, 0);
+        sendBuffer = Buffer.concat([sendBuffer, doneBuffer, mTimeBuffer]);
+      }
+      let packet = await this._sendAndOkay(ADB_COMMANDS.CMD_WRTE
+                                          , localId
+                                          , remoteId
+                                          , sendBuffer);
+      if  (packet.data) {
+        console.log("packet data:", packet.data.toString());
+      }
+      sendBuffer = new Buffer("");
     }
     console.log("_fileLoop finished");
   }
 
+  // function to send a file to the device, part of _push flow
+  // gets some stats about the file, calls _fileLoop, and then finishes
+  // off the push flow and closes the stream
   async _sendFile (filePath, destination, localId, remoteId) {
     let fileName = getFileName(filePath);
     // path where the file will end up on the device, including the file name
     let devicePath = `${destination}/${fileName}`;
     let stats = await statAsync(filePath);
-    let modifiedTime = stats.mtime.getTime() / 1000; //convert ms to s
-    // let fileData = await readFileAsync(filePath);
-    let sizeBuffer = new Buffer(4);
-    sizeBuffer.writeUInt32LE(stats.size, 0);
-    let mTimeBuffer = new Buffer(4);
-    mTimeBuffer.writeUInt32LE(modifiedTime, 0);
-    // we should send the file chunk by chunk instead of reading the entire
-    // file into data and constructing a single buffer to send
-    // let dataBuffer = this._constructFileBuffer(fileData, stats, devicePath);
-    // await this._fileLoop(dataBuffer, localId, remoteId);
     await this._fileLoop(filePath, stats, devicePath, localId, remoteId);
-    console.log("file sending should be finished");
+    console.log("file sending is finished");
     // the device is going to send us a WRTE containing an OKAY as the data
     await this._recvMsg(MAXDATA);
     // now we send it the same thing back

--- a/lib/usb-device.js
+++ b/lib/usb-device.js
@@ -229,6 +229,11 @@ class USBDevice {
         appendDataSize = false;
       }
       let amountToRead = null;
+      // amountToRead should either be MAX_READ, the remaining amount of dataAmount,
+      // or MAX_READ - sendBufferLength which is a case when we've got some data
+      // from a previous DATA<size> in sendBuffer and there is still data in the file
+      // meaning we need to insert another DATA<size> in the current packet we're
+      // building plus more file data
       if (sendBuffer.length === 0) {
         amountToRead = dataAmount > MAX_READ ? MAX_READ : dataAmount;
       } else {
@@ -240,6 +245,10 @@ class USBDevice {
       remaining -= amountToRead;
       dataAmount -= amountToRead;
       currentPosition += amountToRead;
+      // if dataAmount is 0 and there is still some data in the file that means
+      // we're in the case where we need to write another DATA<size> + some file data
+      // to sendBuffer, so we continue the loop in order to keep sendBuffer's current
+      // contents, and to write to it again before we send the packet out to the device
       if (dataAmount === 0 && remaining !== 0) {
         appendDataSize = true;
         dataAmount = remaining > MAX_SIZE ? MAX_SIZE : remaining;

--- a/lib/usb-device.js
+++ b/lib/usb-device.js
@@ -17,14 +17,15 @@ const keyPath = path.join(homedir, ADB_KEY.PUBLIC_KEY);
 const publicKeyString = fs.readFileSync(keyPath);
 const LIBUSB_ENDPOINT_IN = LIBUSB_VALUES.LIBUSB_ENDPOINT_IN
     , LIBUSB_TRANSFER_TYPE_BULK = LIBUSB_VALUES.LIBUSB_TRANSFER_TYPE_BULK;
-const maxRead = 4000;
+const MAX_READ = 4000; // don't send a packet with more than this amount
+const MAX_SIZE = 65536; // max size we can have in one DATA<size>
 const installLocation = "/data/local/tmp/";
 const dataIndicator = new Buffer("DATA");
 
 const statAsync = Promise.promisify(fs.stat);
-// const readAsync = Promise.promisify(fs.read);
-// const openAsync = Promise.promisify(fs.open);
-const readFileAsync = Promise.promisify(fs.readFile);
+const readAsync = Promise.promisify(fs.read);
+const openAsync = Promise.promisify(fs.open);
+// const readFileAsync = Promise.promisify(fs.readFile);
 
 class USBDevice {
   constructor(device, deviceInterface) {
@@ -236,28 +237,59 @@ class USBDevice {
     return sendBuffer;
   }
 
-  async _fileLoop (dataBuffer, localId, remoteId) {
-    let remaining = dataBuffer.length;
-    let amountSent = 0;
-    let payloadBuffer = null;
-    while (remaining !== 0) {
-      if (remaining > maxRead) {
-        payloadBuffer = new Buffer(maxRead);
-        dataBuffer.copy(payloadBuffer, 0, amountSent, amountSent + maxRead);
-      } else {
-        payloadBuffer = new Buffer(remaining);
-        dataBuffer.copy(payloadBuffer, 0 , amountSent, dataBuffer.length);
+  // loop through the dataBuffer, which consists of fileData and ADB related data
+  // necessary to push a file to the device
+  // async _fileLoop (dataBuffer, localId, remoteId) {
+  //   let remaining = dataBuffer.length;
+  //   let amountSent = 0;
+  //   let payloadBuffer = null;
+  //   while (remaining !== 0) {
+  //     if (remaining > maxRead) {
+  //       payloadBuffer = new Buffer(maxRead);
+  //       dataBuffer.copy(payloadBuffer, 0, amountSent, amountSent + maxRead);
+  //     } else {
+  //       payloadBuffer = new Buffer(remaining);
+  //       dataBuffer.copy(payloadBuffer, 0 , amountSent, dataBuffer.length);
+  //     }
+  //     let packet = await this._sendAndOkay(ADB_COMMANDS.CMD_WRTE
+  //                                         , localId
+  //                                         , remoteId
+  //                                         , payloadBuffer);
+  //     if (packet.data) {
+  //       console.log(packet.data.toString());
+  //     }
+  //     amountSent += payloadBuffer.length;
+  //     remaining -= payloadBuffer.length;
+  //   }
+  // }
+  async _fileLoop(filePath, fileStats, devicePath, localId, remoteId) {
+    let sendBuffer = new Buffer(`${devicePath},${fileStats.mode},`);
+    let fd = await openAsync(filePath, 'r');
+    let remaining = fileStats.size;
+    let currentPosition = 0;
+    // DATA<size> can only be 64k or less
+    let dataAmount = remaining > MAX_SIZE ? MAX_SIZE : remaining;
+    while (remaining > 0) {
+      if (dataAmount === (MAX_SIZE || remaining)) {
+        sendBuffer = Buffer.concat([sendBuffer, `DATA${dataAmount}`]);
       }
+      let amountToRead = remaining > MAX_READ ? MAX_READ : remaining;
+      let readBuffer = new Buffer(amountToRead);
+      await readAsync(fd, readBuffer, 0, amountToRead, currentPosition);
+      sendBuffer = Buffer.concat([sendBuffer, readBuffer]);
       let packet = await this._sendAndOkay(ADB_COMMANDS.CMD_WRTE
                                           , localId
                                           , remoteId
-                                          , payloadBuffer);
-      if (packet.data) {
-        console.log(packet.data.toString());
+                                          , sendBuffer);
+      console.log("packet: ", packet);
+      remaining -= amountToRead;
+      dataAmount -= amountToRead;
+      currentPosition += amountToRead;
+      if (dataAmount === 0 && remaining !== 0) {
+        dataAmount = remaining > MAX_SIZE ? MAX_SIZE : remaining;
       }
-      amountSent += payloadBuffer.length;
-      remaining -= payloadBuffer.length;
     }
+    console.log("_fileLoop finished");
   }
 
   async _sendFile (filePath, destination, localId, remoteId) {
@@ -266,15 +298,16 @@ class USBDevice {
     let devicePath = `${destination}/${fileName}`;
     let stats = await statAsync(filePath);
     let modifiedTime = stats.mtime.getTime() / 1000; //convert ms to s
-    let fileData = await readFileAsync(filePath);
+    // let fileData = await readFileAsync(filePath);
     let sizeBuffer = new Buffer(4);
     sizeBuffer.writeUInt32LE(stats.size, 0);
     let mTimeBuffer = new Buffer(4);
     mTimeBuffer.writeUInt32LE(modifiedTime, 0);
     // we should send the file chunk by chunk instead of reading the entire
     // file into data and constructing a single buffer to send
-    let dataBuffer = this._constructFileBuffer(fileData, stats, devicePath);
-    await this._fileLoop(dataBuffer, localId, remoteId);
+    // let dataBuffer = this._constructFileBuffer(fileData, stats, devicePath);
+    // await this._fileLoop(dataBuffer, localId, remoteId);
+    await this._fileLoop(filePath, stats, devicePath, localId, remoteId);
     console.log("file sending should be finished");
     // the device is going to send us a WRTE containing an OKAY as the data
     await this._recvMsg(MAXDATA);


### PR DESCRIPTION
The point of this is previously when we run a push command the entire file would be loaded into memory, and a Buffer would constructed with all the ADB bits in between file data that were necessary.  Now instead we're doing this all within a loop, building one packet and sending it.  

The code for this is a bit ugly, and I'm hoping someone may have ideas on how to clean it up.  The important part is here: https://github.com/appium/node-adb-client/blob/push-rework/lib/usb-device.js#L214-L264

What's happening is that each time we're sending a piece of the file data to the device we need to prefix it with `DATA<size>`, where size can be 64k or less.  After that we just keep sending packets with only file data until we reach whatever `<size>` was.  So if we have a file larger than 64k we'll have to send `DATA<size>` multiple times, where the last one will most likely have a size of less than 64k.  Each packet in ADB seems to have a max size of 4k, so at the end of a 64k `<size>` there will be a small amount of data from that `DATA` prefix, and then we need another `DATA<size>` plus more file data in that packet, otherwise ADB gets mad.  Hopefully that description makes sense.