### PR TITLE
Update examples based on latest working version of ADB code

### DIFF
--- a/lib/examples/install.js
+++ b/lib/examples/install.js
@@ -2,16 +2,24 @@
 import ADB from '../../adb';
 import { CONNECTION_TYPES } from '../constants';
 import { asyncify } from 'asyncbox';
+import path from 'path';
 
 async function start () {
-  let availableDevices = ADB.findAdbDevices();
+  let availableDevices = await ADB.findAdbDevices();
   if (availableDevices.length > 0) {
     let device = new ADB(CONNECTION_TYPES.USB, availableDevices[0]);
     await device.connect();
     console.log("connected");
+    let apkSource = path.resolve(__dirname
+                              , ".."
+                              , ".."
+                              , ".."
+                              , "test"
+                              , "fixtures"
+                              , "contactManager.apk");
     let command = {
       type: "install"
-    , source: "/Users/callumstyan/app-debug.apk"
+    , source: apkSource
     };
     await device.runCommand(command);
     await device.closeConnection();

--- a/lib/examples/pull.js
+++ b/lib/examples/pull.js
@@ -2,18 +2,23 @@
 import ADB from '../../adb';
 import { CONNECTION_TYPES } from '../constants';
 import { asyncify } from 'asyncbox';
+import path from 'path';
 
 async function start () {
-  let availableDevices = ADB.findAdbDevices();
+  let availableDevices = await ADB.findAdbDevices();
   if (availableDevices.length > 0) {
     // just select the first device
     let device = new ADB(CONNECTION_TYPES.USB, availableDevices[0]);
     await device.connect();
     console.log("connected");
+    let destinationFile = path.resolve(__dirname
+                                     , ".."
+                                     , ".."
+                                     , "largeFile");
     let command = {
       type:        "pull"
-    , source:      "sdcard/test.py"
-    , destination: "/Users/callumstyan/test.py"
+    , source:      "sdcard/largeFile"
+    , destination: destinationFile
     };
     await device.runCommand(command);
     await device.closeConnection();

--- a/lib/examples/reboot.js
+++ b/lib/examples/reboot.js
@@ -4,7 +4,7 @@ import { CONNECTION_TYPES } from '../constants';
 import { asyncify } from 'asyncbox';
 
 async function start () {
-let availableDevices = ADB.findAdbDevices();
+let availableDevices = await ADB.findAdbDevices();
   if (availableDevices.length > 0) {
     // just select the first device
     let device = new ADB(CONNECTION_TYPES.USB, availableDevices[0]);

--- a/lib/examples/shell.js
+++ b/lib/examples/shell.js
@@ -2,12 +2,10 @@
 import ADB from '../../adb';
 import { CONNECTION_TYPES } from '../constants';
 import { asyncify } from 'asyncbox';
-// import { getSerialNumbers } from '../helpers';
 
 async function start () {
-  let availableDevices = ADB.findAdbDevices();
+  let availableDevices = await ADB.findAdbDevices();
   if (availableDevices.length > 0) {
-    // await getSerialNumbers(availableDevices);
     // just select the first device
     let device = new ADB(CONNECTION_TYPES.USB, availableDevices[0]);
     await device.connect();

--- a/lib/examples/shellBySerial.js
+++ b/lib/examples/shellBySerial.js
@@ -1,28 +1,26 @@
 // transpile:main
-import { connectToDevice } from '../../index.js';
+import ADB from '../../adb';
 import { CONNECTION_TYPES } from '../constants';
 import { asyncify } from 'asyncbox';
-import { findAdbDevices, getSerialNumbers, selectBySerialNumber } from '../helpers';
+import { selectBySerialNumber } from '../../lib/helpers';
 
 async function start () {
-  let serialNumber = "27b1b2ef";
-  let availableDevices = findAdbDevices();
-  await getSerialNumbers(availableDevices);
-  // get a device by serial number
-  let foundDevice = selectBySerialNumber(availableDevices, serialNumber);
-  let adb = connectToDevice(CONNECTION_TYPES.USB, foundDevice);
-  console.log("adb: ", adb);
-  await adb.initConnection();
-  console.log("Device started.");
-  // opening a stream into the device causes issues atm
-  let command = {
-    type:   "shell"
-  , string: "ls"
-  };
-  await adb.open(command);
-  console.log("shell opened");
-  console.log("closing device!");
-  await adb.closeConnection();
+  let availableDevices = await ADB.findAdbDevices();
+  if (availableDevices.length > 0) {
+    // select device by serial number: 4d00a90c4f041119
+    let serial = "4d00a90c4f041119";
+    let selectedDevice = selectBySerialNumber(availableDevices, serial);
+    let device = new ADB(CONNECTION_TYPES.USB, selectedDevice);
+    await device.connect();
+    console.log("connected");
+    let command = {
+      type:   "shell"
+    , string: "getprop ro.build.version.sdk"
+    };
+    await device.runCommand(command);
+    await device.closeConnection();
+    console.log("closed");
+  }
 }
 
 console.log("Starting.");

--- a/lib/examples/uninstall.js
+++ b/lib/examples/uninstall.js
@@ -2,26 +2,16 @@
 import ADB from '../../adb';
 import { CONNECTION_TYPES } from '../constants';
 import { asyncify } from 'asyncbox';
-import path from 'path';
 
 async function start () {
   let availableDevices = await ADB.findAdbDevices();
   if (availableDevices.length > 0) {
-    // just select the first device
     let device = new ADB(CONNECTION_TYPES.USB, availableDevices[0]);
     await device.connect();
     console.log("connected");
-    let fileSource = path.resolve(__dirname
-                              , ".."
-                              , ".."
-                              , ".."
-                              , "test"
-                              , "fixtures"
-                              , "largeFile");
     let command = {
-      type:        "push"
-    , source:      fileSource
-    , destination: "sdcard/"
+      type: "uninstall"
+    , packageName: "com.example.android.contactmanager"
     };
     await device.runCommand(command);
     await device.closeConnection();


### PR DESCRIPTION
Pretty simple, just updating examples.
- findAdbDevices is now async so examples need to `await` on that function
- make use of path module rather than hardcoding paths for file source and destination in some examples
- update shellBySerial example since that functionality is actually working now
- add uninstall example

cc: @imurchie 