### PR TITLE
[WIP] Add list cmd

### DIFF
--- a/lib/adb-device.js
+++ b/lib/adb-device.js
@@ -226,6 +226,11 @@ class ADBDevice {
             case 'modified':
               file.modified = new Date(chunk * 1000);
               break;
+            case 'mode':
+              file.type = chunk >> 13;
+              // Just get the 9-bits that signify the UNIX file mode
+              file.mode = chunk & ~0b1111111000000000;
+              break;
             default:
               file[props[i]] = chunk;
           }

--- a/lib/adb-device.js
+++ b/lib/adb-device.js
@@ -1,5 +1,5 @@
 import { CONNECTION_TYPES, ADB_COMMANDS, CONNECT_VALUES
-       , ADB_KEY, ADB_SUBCOMMANDS } from './constants';
+       , ADB_KEY, ADB_SUBCOMMANDS, FILE_TYPES } from './constants';
 import { getFileName, parseFileData, logExceptOnTest } from './helpers';
 import USBDevice from './usb-device';
 
@@ -274,9 +274,9 @@ class ADBDevice {
     // this is our remote id, the devices local id
     let remoteId = packet.arg1;
     packet = await this.stat(remotePath, localId, remoteId);
-    let mode = packet.data.readUInt32LE(4);
-    if (mode === 0) { // file doesn't exist
-      logExceptOnTest("The file you're trying to pull doesn't exist.");
+    let fileType = packet.data.readUInt32LE(4) >>> 13;
+    if (fileType === FILE_TYPES.FILE || fileType === 0) { // remotePath is a file or doesn't exist
+      logExceptOnTest("The remote path does not exist or is a file, not a directory.");
       await this.close(localId, remoteId);
       return -1;
     }

--- a/lib/adb-device.js
+++ b/lib/adb-device.js
@@ -214,15 +214,21 @@ class ADBDevice {
           delete file.length;
           files.push(file);
           file = {};
-        } else if (props[i] === 'cmd') {
-          let cmd = packet.data.readUInt32LE(pos);
-          if (cmd === ADB_SUBCOMMANDS.CMD_DONE) {
-            run = false;
-            break;
-          }
-          pos += 4;
         } else {
-          file[props[i]] = packet.data.readUInt32LE(pos);
+          let chunk = packet.data.readUInt32LE(pos);
+          switch (props[i]) {
+            case 'cmd':
+              if (chunk === ADB_SUBCOMMANDS.CMD_DONE) {
+                run = false;
+                pos = Infinity;
+              }
+              break;
+            case 'modified':
+              file.modified = new Date(chunk * 1000);
+              break;
+            default:
+              file[props[i]] = chunk;
+          }
           pos += 4;
         }
         i = (i + 1) % props.length;

--- a/lib/adb-device.js
+++ b/lib/adb-device.js
@@ -190,7 +190,10 @@ class ADBDevice {
     return data;
   }
 
+  // Receive a file listing and parse it into an array of file objects.
   async recvList(localId, remoteId) {
+    // This is the structure of each directory entry returned by LIST
+    // see https://android.googlesource.com/platform/system/core/+/master/adb/SYNC.TXT#39
     const props = [
       'cmd',
       'mode',
@@ -202,7 +205,7 @@ class ADBDevice {
     const files = [];
     let file = {};
     let i = 0;
-    let run = true;
+    let done = false;
 
     do {
       let packet = await this.recvAndOkay(localId, remoteId);
@@ -219,7 +222,8 @@ class ADBDevice {
           switch (props[i]) {
             case 'cmd':
               if (chunk === ADB_SUBCOMMANDS.CMD_DONE) {
-                run = false;
+                done = true;
+                // hacky way to break out of this inner loop
                 pos = Infinity;
               }
               break;
@@ -234,11 +238,15 @@ class ADBDevice {
             default:
               file[props[i]] = chunk;
           }
+          // Move to the next chunk to process from the packet
           pos += 4;
         }
+        // Keep cycling through the props in order
         i = (i + 1) % props.length;
+        // continue parsing through the packet until we reach the end of the packet
       } while (pos < packet.data.length);
-    } while (run === true);
+      // Keep requesting new packets until we receive 'DONE'
+    } while (done === false);
     return files;
   }
 
@@ -266,10 +274,16 @@ class ADBDevice {
     await this.sendFile(source, destination, localId, remoteId);
   }
 
-  // runs ADB push to push a file to the device
+  // runs LIST sync request to list files in a folder
+  // If remotePath does not exist or is not a folder will return an empty array.
+  // returns an array of file listing objects with properties:
+  // type {number} - one of `0b100` (file), `0b010` (directory), `0b101` (symlink)
+  // mode {number} - `chmod` mode e.g. file permissions as per unix standard.
+  // modified {date} - file modification date
+  // filename {string} - filename
   async list (remotePath) {
     let syncBuf = new Buffer("sync:.");
-    // open a SYNC stream on the device for pushing the file
+    // open a SYNC stream on the device for listing files in a folder
     let packet = await this.sendAndOkay(ADB_COMMANDS.CMD_OPEN
                                        , 12345
                                        , 0
@@ -285,6 +299,7 @@ class ADBDevice {
                                    , localId
                                    , remoteId
                                    , listBuffer);
+    // Send the path to the folder to list files within
     packet = await this.sendAndOkay(ADB_COMMANDS.CMD_WRTE
                                    , localId
                                    , remoteId

--- a/lib/adb-device.js
+++ b/lib/adb-device.js
@@ -305,6 +305,8 @@ class ADBDevice {
     logExceptOnTest("sent remote path to list");
     // recv the file data from the device
     let files = await this.recvList(localId, remoteId);
+    // remove `.` and `..` file entries
+    files = files.filter(file => file.filename !== '.' && file.filename !== '..');
     return files;
   }
 

--- a/lib/adb-device.js
+++ b/lib/adb-device.js
@@ -1,5 +1,5 @@
 import { CONNECTION_TYPES, ADB_COMMANDS, CONNECT_VALUES
-       , ADB_KEY, ADB_SUBCOMMANDS, FILE_TYPES } from './constants';
+       , ADB_KEY, ADB_SUBCOMMANDS } from './constants';
 import { getFileName, parseFileData, logExceptOnTest } from './helpers';
 import USBDevice from './usb-device';
 
@@ -278,13 +278,6 @@ class ADBDevice {
     let localId = packet.arg2;
     // this is our remote id, the devices local id
     let remoteId = packet.arg1;
-    packet = await this.stat(remotePath, localId, remoteId);
-    let fileType = packet.data.readUInt32LE(4) >>> 13;
-    if (fileType === FILE_TYPES.FILE || fileType === 0) { // remotePath is a file or doesn't exist
-      logExceptOnTest("The remote path does not exist or is a file, not a directory.");
-      await this.close(localId, remoteId);
-      return -1;
-    }
     let listBuffer = new Buffer(8);
     listBuffer.writeUInt32LE(ADB_SUBCOMMANDS.CMD_LIST, 0);
     listBuffer.writeUInt32LE(remotePath.length, 4);

--- a/lib/adb-device.js
+++ b/lib/adb-device.js
@@ -190,6 +190,47 @@ class ADBDevice {
     return data;
   }
 
+  async recvList(localId, remoteId) {
+    const props = [
+      'cmd',
+      'mode',
+      'size',
+      'modified',
+      'length',
+      'filename'
+    ];
+    const files = [];
+    let file = {};
+    let i = 0;
+    let run = true;
+
+    do {
+      let packet = await this.recvAndOkay(localId, remoteId);
+      let pos = 0;
+      do {
+        if (props[i] === 'filename') {
+          file.filename = packet.data.slice(pos, pos + file.length).toString();
+          pos += file.length;
+          delete file.length;
+          files.push(file);
+          file = {};
+        } else if (props[i] === 'cmd') {
+          let cmd = packet.data.readUInt32LE(pos);
+          if (cmd === ADB_SUBCOMMANDS.CMD_DONE) {
+            run = false;
+            break;
+          }
+          pos += 4;
+        } else {
+          file[props[i]] = packet.data.readUInt32LE(pos);
+          pos += 4;
+        }
+        i = (i + 1) % props.length;
+      } while (pos < packet.data.length);
+    } while (run === true);
+    return files;
+  }
+
   // runs ADB push to push a file to the device
   async push (source, destination) {
     let syncBuf = new Buffer("sync:.");
@@ -212,6 +253,43 @@ class ADBDevice {
                                    , remoteId
                                    , sendBuffer);
     await this.sendFile(source, destination, localId, remoteId);
+  }
+
+  // runs ADB push to push a file to the device
+  async list (remotePath) {
+    let syncBuf = new Buffer("sync:.");
+    // open a SYNC stream on the device for pushing the file
+    let packet = await this.sendAndOkay(ADB_COMMANDS.CMD_OPEN
+                                       , 12345
+                                       , 0
+                                       , syncBuf);
+    // this is our local id, the devices remote id
+    let localId = packet.arg2;
+    // this is our remote id, the devices local id
+    let remoteId = packet.arg1;
+    packet = await this.stat(remotePath, localId, remoteId);
+    let mode = packet.data.readUInt32LE(4);
+    console.log(mode, packet.data.readUInt32LE(0), packet.data.readUInt32LE(8), packet.data.readUInt32LE(12));
+    if (mode === 0) { // file doesn't exist
+      logExceptOnTest("The file you're trying to pull doesn't exist.");
+      await this.close(localId, remoteId);
+      return -1;
+    }
+    let listBuffer = new Buffer(8);
+    listBuffer.writeUInt32LE(ADB_SUBCOMMANDS.CMD_LIST, 0);
+    listBuffer.writeUInt32LE(remotePath.length, 4);
+    packet = await this.sendAndOkay(ADB_COMMANDS.CMD_WRTE
+                                   , localId
+                                   , remoteId
+                                   , listBuffer);
+    packet = await this.sendAndOkay(ADB_COMMANDS.CMD_WRTE
+                                   , localId
+                                   , remoteId
+                                   , remotePath);
+    logExceptOnTest("sent remote path to list");
+    // recv the file data from the device
+    let files = await this.recvList(localId, remoteId);
+    return files;
   }
 
   // runs ADB pull to pull a file from the device to the local machine
@@ -348,6 +426,9 @@ class ADBDevice {
         break;
       case "pull":
         output = await this.pull(command.source, command.destination);
+        break;
+      case "list":
+        output = await this.list(command.remotePath);
         break;
       case "install":
         await this.install(command.source);

--- a/lib/adb-device.js
+++ b/lib/adb-device.js
@@ -275,7 +275,6 @@ class ADBDevice {
     let remoteId = packet.arg1;
     packet = await this.stat(remotePath, localId, remoteId);
     let mode = packet.data.readUInt32LE(4);
-    console.log(mode, packet.data.readUInt32LE(0), packet.data.readUInt32LE(8), packet.data.readUInt32LE(12));
     if (mode === 0) { // file doesn't exist
       logExceptOnTest("The file you're trying to pull doesn't exist.");
       await this.close(localId, remoteId);

--- a/lib/adb-device.js
+++ b/lib/adb-device.js
@@ -205,9 +205,10 @@ class ADBDevice {
     const files = [];
     let file = {};
     let i = 0;
-    let done = false;
 
-    do {
+    // Keep requesting new packets until we receive 'DONE'
+    // TODO: Do we need a timeout in case 'DONE' is never sent? Shouldn't happen
+    while (true) {
       let packet = await this.recvAndOkay(localId, remoteId);
       let pos = 0;
       do {
@@ -222,9 +223,8 @@ class ADBDevice {
           switch (props[i]) {
             case 'cmd':
               if (chunk === ADB_SUBCOMMANDS.CMD_DONE) {
-                done = true;
-                // hacky way to break out of this inner loop
-                pos = Infinity;
+                // Break the loop and return the files
+                return files;
               }
               break;
             case 'modified':
@@ -245,9 +245,7 @@ class ADBDevice {
         i = (i + 1) % props.length;
         // continue parsing through the packet until we reach the end of the packet
       } while (pos < packet.data.length);
-      // Keep requesting new packets until we receive 'DONE'
-    } while (done === false);
-    return files;
+    }
   }
 
   // runs ADB push to push a file to the device

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -81,6 +81,7 @@ const ADB_SUBCOMMANDS = {
 , CMD_FAIL: 0x4c494146
 , CMD_DONE: 0x454e4f44
 , CMD_DATA: 0x41544144
+, CMD_LIST: 0x5453494c
 };
 
 //TODO: detect these or command line arguement?

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -84,6 +84,12 @@ const ADB_SUBCOMMANDS = {
 , CMD_LIST: 0x5453494c
 };
 
+const FILE_TYPES = {
+  FILE: 0b100
+, DIRECTORY: 0b010
+, SYMLINK: 0b101
+};
+
 //TODO: detect these or command line arguement?
 const ADB_KEY = {
   PUBLIC_KEY:  ".android/adbkey.pub"
@@ -102,4 +108,4 @@ const LIBUSB_VALUES = {
 };
 
 export { USB_VENDOR_IDS, ADB_VALUES, CONNECT_VALUES, ADB_COMMANDS
-       , ADB_SUBCOMMANDS, ADB_KEY, CONNECTION_TYPES, LIBUSB_VALUES };
+       , ADB_SUBCOMMANDS, ADB_KEY, CONNECTION_TYPES, LIBUSB_VALUES, FILE_TYPES };

--- a/lib/examples/list.es5.js
+++ b/lib/examples/list.es5.js
@@ -1,0 +1,25 @@
+var ADB = require('./build/adb');
+var CONNECTION_TYPES = require('./build/lib/constants').CONNECTION_TYPES;
+
+console.log("Starting.");
+var device;
+
+ADB.findAdbDevices().then(function (availableDevices) {
+  if (availableDevices.length === 0) return;
+  device = new ADB(CONNECTION_TYPES.USB, availableDevices[0]);
+  return device.connect();
+}).then(function () {
+  console.log("connected");
+  var command = {
+    type:   "list"
+  , remotePath: "sdcard"
+  };
+  return device.runCommand(command);
+}).then(function (output) {
+  console.log(output);
+  return device.closeConnection();
+}).then(function () {
+  console.log('closed');
+}).catch(function (err) {
+  console.log(err);
+});

--- a/lib/examples/list.js
+++ b/lib/examples/list.js
@@ -1,0 +1,24 @@
+// transpile:main
+import ADB from '../../adb';
+import { CONNECTION_TYPES } from '../constants';
+import { asyncify } from 'asyncbox';
+
+async function start () {
+  let availableDevices = await ADB.findAdbDevices();
+  if (availableDevices.length > 0) {
+    // just select the first device
+    let device = new ADB(CONNECTION_TYPES.USB, availableDevices[0]);
+    await device.connect();
+    console.log("connected");
+    let command = {
+      type:   "list"
+    , remotePath: "sdcard"
+    };
+    let output = await device.runCommand(command);
+    await device.closeConnection();
+    console.log(output);
+  }
+}
+
+console.log("Starting.");
+asyncify(start);

--- a/test/unit/adb-device-specs.js
+++ b/test/unit/adb-device-specs.js
@@ -134,6 +134,17 @@ describe('adb-device', () => {
       await adbDevice.open(command);
       verify(mocks);
     });
+    it('should call list if command.type is pull', async () => {
+      let command = {
+        type: "list"
+      , remotePath: "test"
+      };
+      mocks.adbDevice.expects('list')
+        .once()
+        .withExactArgs(command.remotePath);
+      await adbDevice.open(command);
+      verify(mocks);
+    });
     it('should call install if command.type is install', async () => {
       let command = {
         type: "install"


### PR DESCRIPTION
This adds the `list` command, fixes #14 

Lists files/directories in the directory `remotePath`. See https://github.com/gmaclennan/node-adb-client/blob/add-list-cmd/lib/examples/list.js

Still to do, help appreciated:

- [x] Add tests
- [x] Check that `remotePath` is a directory and not a file
- [x] Figure out how to interpret `mode`
- [x] Figure our how to interpret `modified`
