### PR TITLE
Update travis config for node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,18 @@
 language: node_js
 node_js:
-  - "0.12"
+  - "4"
+  - "6"
+  - "7"
+env:
+  - CXX=g++-4.8
 addons:
   apt:
+    sources:
+      - ubuntu-toolchain-r-test
     packages:
     - build-essential
     - libudev-dev
+    - g++-4.8
 before_script:
   - mkdir ~/.android
   - touch ~/.android/adbkey.pub


### PR DESCRIPTION
Update so that the build can pass, and so that we are testing relevant Node versions.

For the `env` and `app` sections, see https://docs.travis-ci.com/user/languages/javascript-with-nodejs#Node.js-v4-(or-io.js-v3)-compiler-requirements